### PR TITLE
Fix Strudel REPL height to keep status bar at bottom

### DIFF
--- a/src/strudel/components/strudel-repl.tsx
+++ b/src/strudel/components/strudel-repl.tsx
@@ -15,7 +15,7 @@ export function StrudelRepl() {
   }, [ref, setRoot]);
 
   return (
-    <div className="relative h-full w-full flex flex-col">
+    <div className="relative flex-1 min-h-0 w-full flex flex-col">
       <ReplTabs />
       <div
         ref={ref}


### PR DESCRIPTION
## Summary

- Changed `h-full` to `flex-1 min-h-0` on the StrudelRepl container
- This ensures the REPL fills available space while the status bar stays fixed at the bottom
- The `min-h-0` prevents flex overflow issues with large content