### PR TITLE
fix: upgrade better-auth to 1.4.9 (GHSA-xg6x-h9c9-2m83)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@tailwindcss/oxide": "^4.1.17",
         "@tambo-ai/react": "^1.2.5",
         "@types/better-sqlite3": "^7.6.13",
-        "better-auth": "^1.4.7",
+        "better-auth": "^1.4.9",
         "better-sqlite3": "^12.5.0",
         "class-variance-authority": "^0.7.1",
         "dompurify": "^3.3.1",
@@ -1250,9 +1250,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
-      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -5318,18 +5318,18 @@
       }
     },
     "node_modules/better-auth": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.7.tgz",
-      "integrity": "sha512-kVmDQxzqGwP4FFMOYpS5I7oAaoFW3hwooUAAtcbb2DrOYv5EUvRUDJbTMaPoMTj7URjNDQ6vG9gcCS1Q+0aVBw==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.9.tgz",
+      "integrity": "sha512-usSdjuyTzZwIvM8fjF8YGhPncxV3MAg3dHUO9uPUnf0yklXUSYISiH1+imk6/Z+UBqsscyyPRnbIyjyK97p7YA==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.7",
-        "@better-auth/telemetry": "1.4.7",
+        "@better-auth/core": "1.4.9",
+        "@better-auth/telemetry": "1.4.9",
         "@better-auth/utils": "0.3.0",
         "@better-fetch/fetch": "1.1.21",
         "@noble/ciphers": "^2.0.0",
         "@noble/hashes": "^2.0.0",
-        "better-call": "1.1.5",
+        "better-call": "1.1.7",
         "defu": "^6.1.4",
         "jose": "^6.1.0",
         "kysely": "^0.28.5",
@@ -5338,22 +5338,22 @@
       },
       "peerDependencies": {
         "@lynx-js/react": "*",
-        "@prisma/client": "^5.22.0",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "@sveltejs/kit": "^2.0.0",
         "@tanstack/react-start": "^1.0.0",
-        "better-sqlite3": "^12.4.1",
-        "drizzle-kit": "^0.31.4",
-        "drizzle-orm": "^0.41.0",
-        "mongodb": "^6.18.0",
-        "mysql2": "^3.14.4",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": ">=0.41.0",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "pg": "^8.16.3",
-        "prisma": "^5.22.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
         "solid-js": "^1.0.0",
         "svelte": "^4.0.0 || ^5.0.0",
-        "vitest": "^4.0.15",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
         "vue": "^3.0.0"
       },
       "peerDependenciesMeta": {
@@ -5414,9 +5414,9 @@
       }
     },
     "node_modules/better-auth/node_modules/@better-auth/core": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.7.tgz",
-      "integrity": "sha512-rNfj8aNFwPwAMYo+ahoWDsqKrV7svD3jhHSC6+A77xxKodbgV0UgH+RO21GMaZ0PPAibEl851nw5e3bsNslW/w==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.9.tgz",
+      "integrity": "sha512-JT2q4NDkQzN22KclUEoZ7qU6tl9HUTfK1ctg2oWlT87SEagkwJcnrUwS9VznL+u9ziOIfY27P0f7/jSnmvLcoQ==",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.1.12"
@@ -5424,28 +5424,28 @@
       "peerDependencies": {
         "@better-auth/utils": "0.3.0",
         "@better-fetch/fetch": "1.1.21",
-        "better-call": "1.1.5",
+        "better-call": "1.1.7",
         "jose": "^6.1.0",
         "kysely": "^0.28.5",
         "nanostores": "^1.0.1"
       }
     },
     "node_modules/better-auth/node_modules/@better-auth/telemetry": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.7.tgz",
-      "integrity": "sha512-k07C/FWnX6m+IxLruNkCweIxuaIwVTB2X40EqwamRVhYNBAhOYZFGLHH+PtQyM+Yf1Z4+8H6MugLOXSreXNAjQ==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.9.tgz",
+      "integrity": "sha512-Tthy1/Gmx+pYlbvRQPBTKfVei8+pJwvH1NZp+5SbhwA6K2EXIaoonx/K6N/AXYs2aKUpyR4/gzqDesDjL7zd6A==",
       "dependencies": {
         "@better-auth/utils": "0.3.0",
         "@better-fetch/fetch": "1.1.21"
       },
       "peerDependencies": {
-        "@better-auth/core": "1.4.7"
+        "@better-auth/core": "1.4.9"
       }
     },
     "node_modules/better-auth/node_modules/nanostores": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.1.0.tgz",
-      "integrity": "sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.2.0.tgz",
+      "integrity": "sha512-F0wCzbsH80G7XXo0Jd9/AVQC7ouWY6idUCTnMwW5t/Rv9W8qmO6endavDwg7TNp5GbugwSukFMVZqzPSrSMndg==",
       "funding": [
         {
           "type": "github",
@@ -5458,9 +5458,9 @@
       }
     },
     "node_modules/better-call": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.5.tgz",
-      "integrity": "sha512-nQJ3S87v6wApbDwbZ++FrQiSiVxWvZdjaO+2v6lZJAG2WWggkB2CziUDjPciz3eAt9TqfRursIQMZIcpkBnvlw==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.7.tgz",
+      "integrity": "sha512-6gaJe1bBIEgVebQu/7q9saahVzvBsGaByEnE8aDVncZEDiJO7sdNB28ot9I6iXSbR25egGmmZ6aIURXyQHRraQ==",
       "license": "MIT",
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
@@ -9012,9 +9012,9 @@
       }
     },
     "node_modules/kysely": {
-      "version": "0.28.9",
-      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.9.tgz",
-      "integrity": "sha512-3BeXMoiOhpOwu62CiVpO6lxfq4eS6KMYfQdMsN/2kUCRNuF2YiEr7u0HLHaQU+O4Xu8YXE3bHVkwaQ85i72EuA==",
+      "version": "0.28.16",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.16.tgz",
+      "integrity": "sha512-3i5pmOiZvMDj00qhrIVbH0AnioVTx22DMP7Vn5At4yJO46iy+FM8Y/g61ltenLVSo3fiO8h8Q3QOFgf/gQ72ww==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -14283,9 +14283,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@tailwindcss/oxide": "^4.1.17",
     "@tambo-ai/react": "^1.2.5",
     "@types/better-sqlite3": "^7.6.13",
-    "better-auth": "^1.4.7",
+    "better-auth": "^1.4.9",
     "better-sqlite3": "^12.5.0",
     "class-variance-authority": "^0.7.1",
     "dompurify": "^3.3.1",


### PR DESCRIPTION
## Summary
- Upgrades `better-auth` from 1.4.7 to 1.4.9 to fix a 2FA bypass vulnerability (GHSA-xg6x-h9c9-2m83)
- The vulnerability allows Two-Factor Authentication bypass via premature session caching (`session.cookieCache`)
- Build verified passing

## Test plan
- [x] `npm run build` passes
- [ ] Verify auth flows still work in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)